### PR TITLE
fix : data is in an array not an object

### DIFF
--- a/src/ImagineEasy/Stack/GitHubOrgAuth.php
+++ b/src/ImagineEasy/Stack/GitHubOrgAuth.php
@@ -124,7 +124,7 @@ class GitHubOrgAuth implements HttpKernel\HttpKernelInterface
             ->json()
         ;
 
-        if (false == is_object($response) || false ==  property_exists($response, 'login')) {
+        if (false == is_array($response) || false == array_key_exists('login', $response)) {
             throw new HttpKernel\Exception\LengthRequiredHttpException("The user has no user details.");
         }
 

--- a/src/ImagineEasy/Stack/GitHubOrgAuth.php
+++ b/src/ImagineEasy/Stack/GitHubOrgAuth.php
@@ -124,7 +124,7 @@ class GitHubOrgAuth implements HttpKernel\HttpKernelInterface
             ->json()
         ;
 
-        if (false == is_array($response) || false == array_key_exists('login', $response)) {
+        if (false === is_array($response) || false === array_key_exists('login', $response)) {
             throw new HttpKernel\Exception\LengthRequiredHttpException("The user has no user details.");
         }
 


### PR DESCRIPTION
https://github.com/easybib/issues/issues/4824

Allows user details to be displayed for the logged in user

The data returned by github for a user is converted into an array not an object, this fixes to work with an array rather than an object.